### PR TITLE
Unset LD_PRELOAD

### DIFF
--- a/am-libexec-packaged
+++ b/am-libexec-packaged
@@ -1,4 +1,4 @@
-#!/data/data/com.termux/files/usr/bin/bash
+#!/data/data/com.termux/files/usr/bin/sh
 export CLASSPATH=/data/data/com.termux/files/usr/libexec/termux-am/am.apk
-unset LD_LIBRARY_PATH
+unset LD_LIBRARY_PATH LD_PRELOAD
 exec /system/bin/app_process / com.example.termuxam.Am "$@"


### PR DESCRIPTION
By unsetting LD_PRELOAD we avoid issues on some devices where dex2oat is a 32-bit binary, resuting in:

CANNOT LINK EXECUTABLE "/system/bin/dex2oat":
"libtermux-exec.so" is 64-bit instead of 32-bit

Also switch from bash to sh as the script doesn't require bash.

This unsetting of LD_PRELOAD is patched into the 0.1-1 version of the termux-am package to fix the issue above (reported in https://github.com/termux/termux-api/issues/105).